### PR TITLE
Add Event API to Default Configuration Modification

### DIFF
--- a/src/main/java/eu/pb4/ouch/DamageDisplayLogic.java
+++ b/src/main/java/eu/pb4/ouch/DamageDisplayLogic.java
@@ -1,8 +1,8 @@
 package eu.pb4.ouch;
 
-import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import eu.pb4.ouch.api.DefaultDisplayEvents;
 import eu.pb4.placeholders.api.ParserContext;
 import eu.pb4.placeholders.api.PlaceholderContext;
 import eu.pb4.placeholders.api.parsers.NodeParser;
@@ -20,16 +20,11 @@ import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.registry.entry.RegistryEntryList;
-import net.minecraft.registry.entry.RegistryEntryListCodec;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.text.Text;
-import net.minecraft.util.dynamic.Codecs;
 import net.minecraft.util.math.MathHelper;
-import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -87,7 +82,7 @@ public record DamageDisplayLogic(Optional<RegistryEntryList<DamageType>> type,
                 BuiltinPredicates.alwaysTrue(),
                 BuiltinPredicates.alwaysTrue(),
                 1,
-                WrappedText.from(PARSER, format),
+                WrappedText.from(PARSER, DefaultDisplayEvents.MODIFY_DISPLAY_LOGIC.invoker().modify(wrapper, List.of(type), format)),
                 FloatingText.DisplaySettings.GENERAL
         );
     }
@@ -97,7 +92,7 @@ public record DamageDisplayLogic(Optional<RegistryEntryList<DamageType>> type,
                 BuiltinPredicates.alwaysTrue(),
                 BuiltinPredicates.alwaysTrue(),
                 1,
-                WrappedText.from(PARSER, format),
+                WrappedText.from(PARSER, DefaultDisplayEvents.MODIFY_DISPLAY_LOGIC.invoker().modify(wrapper, type, format)),
                 FloatingText.DisplaySettings.GENERAL
         );
     }

--- a/src/main/java/eu/pb4/ouch/DeathDisplayLogic.java
+++ b/src/main/java/eu/pb4/ouch/DeathDisplayLogic.java
@@ -1,6 +1,5 @@
 package eu.pb4.ouch;
 
-import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import eu.pb4.placeholders.api.ParserContext;
@@ -21,11 +20,8 @@ import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.registry.entry.RegistryEntryList;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.text.Text;
-import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;

--- a/src/main/java/eu/pb4/ouch/DefaultDisplay.java
+++ b/src/main/java/eu/pb4/ouch/DefaultDisplay.java
@@ -1,9 +1,13 @@
 package eu.pb4.ouch;
 
+import eu.pb4.ouch.api.DefaultDisplayEvents;
 import eu.pb4.predicate.api.BuiltinPredicates;
+import net.minecraft.entity.damage.DamageType;
 import net.minecraft.entity.damage.DamageTypes;
 import net.minecraft.registry.DynamicRegistryManager;
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.tag.DamageTypeTags;
+import net.minecraft.util.Pair;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +46,10 @@ public interface DefaultDisplay {
         damage.add(DamageDisplayLogic.of("<#ff0000>-${value}</>"));
 
         heal.add(HealDisplayLogic.of("<#00FF00>+${value}"));
+
+        LogicsImpl logics = new LogicsImpl();
+        DefaultDisplayEvents.APPEND_DISPLAY_LOGIC.invoker().append(lookup, logics);
+        logics.getLogics().forEach(pair -> damage.add(DamageDisplayLogic.of(lookup, pair.getLeft(), pair.getRight())));
     }
 
     static void createShowcase(List<DamageDisplayLogic> damage, List<HealDisplayLogic> heal, List<DeathDisplayLogic> death,
@@ -50,5 +58,20 @@ public interface DefaultDisplay {
 
         death.add(DeathDisplayLogic.of("<red>${message}"));
         damageExtra.add(DamageDisplayLogic.of(0.03f, BuiltinPredicates.alwaysTrue(), "<white>Ouch!"));
+    }
+
+    class LogicsImpl implements DefaultDisplayEvents.AppendDisplayLogic.Logics {
+
+        final List<Pair<List<RegistryKey<DamageType>>, String>> logics = new ArrayList<>();
+
+        @Override
+        @SafeVarargs
+        public final void add(String format, RegistryKey<DamageType>... types) {
+            this.logics.add(new Pair<>(List.of(types), format));
+        }
+
+        List<Pair<List<RegistryKey<DamageType>>, String>> getLogics() {
+            return this.logics;
+        }
     }
 }

--- a/src/main/java/eu/pb4/ouch/api/DefaultDisplayEvents.java
+++ b/src/main/java/eu/pb4/ouch/api/DefaultDisplayEvents.java
@@ -1,0 +1,75 @@
+package eu.pb4.ouch.api;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.entity.damage.DamageType;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryWrapper;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.List;
+
+public final class DefaultDisplayEvents {
+
+	/**
+	 * This event allows to append a format applied on one or more {@link DamageType} for the default configuration.
+	 * Example:
+	 * <pre>
+	 * {@code
+	 *  DefaultDisplayEvents.APPEND_DISPLAY_LOGIC.register((lookup, logics) -> {
+	 *      logics.add(firstDamageFormat, firstDamageTypes...);
+	 *      logics.add(secondDamageFormat, secondDamageTypes...);
+	 *      logics.add(thirdDamageFormat, thirdDamageTypes...);
+	 *      return logics;
+	 *  });
+	 * }
+	 * </pre>
+	 */
+	public static final Event<AppendDisplayLogic> APPEND_DISPLAY_LOGIC = EventFactory.createArrayBacked(AppendDisplayLogic.class, callbacks -> (lookup, _logics) -> {
+		AppendDisplayLogic.Logics logics = _logics;
+		for (AppendDisplayLogic callback : callbacks) {
+			logics = callback.append(lookup, logics);
+		}
+		return logics;
+	});
+
+	/**
+	 * This event allows to modify a format applied on one or more {@link DamageType} for the default configuration.
+	 * Example:
+	 * <pre>
+	 * {@code
+	 *  DefaultDisplayEvents.MODIFY_DISPLAY_LOGIC.register((lookup, types, format) -> {
+	 *      if (types.contains(DamageTypes.OUT_OF_WORLD)) {
+	 *          return yourModifiedFormat;
+	 *      }
+	 *      return format;
+	 *  });
+	 * }
+	 * </pre>
+	 */
+	public static final Event<ModifyDisplayLogic> MODIFY_DISPLAY_LOGIC = EventFactory.createArrayBacked(ModifyDisplayLogic.class, callbacks -> (lookup, types, _format) -> {
+		String format = _format;
+		for (ModifyDisplayLogic callback : callbacks) {
+			format = callback.modify(lookup, types, format);
+		}
+		return format;
+	});
+
+	@FunctionalInterface
+	public interface AppendDisplayLogic {
+
+		Logics append(RegistryWrapper.WrapperLookup lookup, Logics logics);
+
+		@ApiStatus.NonExtendable
+		interface Logics {
+
+			void add(String format, RegistryKey<DamageType>... types);
+		}
+	}
+
+	@FunctionalInterface
+	public interface ModifyDisplayLogic {
+
+		String modify(RegistryWrapper.WrapperLookup lookup, List<RegistryKey<DamageType>> types, String format);
+	}
+}


### PR DESCRIPTION
You told me to done this via mixins, but I honestly felt it'd be better with an official api.

This PR proposes two new events: `DefautDisplayEvents#APPEND_DISPLAY_LOGIC` and `DefaultDisplayEvents#MODIFY_DISPLAY_LOGIC`.

Explanations (same as in the javadocs):

DefautDisplayEvents#APPEND_DISPLAY_LOGIC allows to append a format applied on one or more `DamageType` for the default configuration.
Example:
```java
DefaultDisplayEvents.APPEND_DISPLAY_LOGIC.register((lookup, logics) -> {
    logics.add(firstDamageFormat, firstDamageTypes...);
    logics.add(secondDamageFormat, secondDamageTypes...);
    logics.add(thirdDamageFormat, thirdDamageTypes...);
    return logics;
});
```

DefaultDisplayEvents#MODIFY_DISPLAY_LOGIC allows to modify a format applied on one or more `DamageType` for the default configuration.
Example:
```java
DefaultDisplayEvents.MODIFY_DISPLAY_LOGIC.register((lookup, types, format) -> {
    if (types.contains(DamageTypes.OUT_OF_WORLD)) {
        return yourModifiedFormat;
    }
    return format;
});
```