### PR TITLE
Remove Redundant Cardboard/Arclight/Banner incompatibility warning/error

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,10 +30,5 @@
     "minecraft": ">=1.21-",
     "polymer-virtual-entity": ">=0.9.0",
     "java": ">=21"
-  },
-  "breaks": {
-    "banner": "*",
-    "cardboard": "*",
-    "arclight": "*"
   }
 }


### PR DESCRIPTION
Polymer which is a dependency of this mod already has a clear warning about the use of Plugin + Mod solutions breaking mods. So I thought that this forceful way of not letting server admins who use Plugin + Mod solutions use the mod is redundant and a bit misleading, as they _can_ make the mod break, but that doesn't mean it **will**. Also the mod works on some solutions such as Arclight, and most players probably know the mod compatibility issues already, but would still use such solutions as sometimes the benefits outweigh the tradeoffs.